### PR TITLE
opencode: bind ~/.opencode so config and binaries are found

### DIFF
--- a/ai-bwrap
+++ b/ai-bwrap
@@ -70,6 +70,7 @@ agent_opencode() {
         --bind "$data"   "$data"
         --bind "$cache"  "$cache"
         --bind "$state"  "$state"
+        --ro-bind-try "$HOME/.opencode" "$HOME/.opencode"
     )
     EXEC_CMD=("$(require_cmd opencode)")
 }


### PR DESCRIPTION

## What & why

The official install script installs opencode to ~/.opencode/bin, so (try) bind it read-only to make the binary and config available.

## Checklist

- [x] `shellcheck ai-bwrap` is clean
- [x] Verified (paste relevant output below if helpful)

## Notes

<!-- Anything reviewers should know: tradeoffs, follow-ups, etc. -->
