### PR TITLE
claude: drop --dangerously-skip-permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `EXTRA_BINDS` / `EXTRA_RO_BINDS` config hooks for shared passthrough mounts.
 - `scripts/screenshots.sh` to regenerate README images with `freeze`.
 
+### Changed
+
+- The `claude` agent no longer runs with `--dangerously-skip-permissions`; it
+  starts with Claude Code's own default permission mode. Pass the flag yourself
+  if you want the old behaviour: `ai-bwrap claude -- --dangerously-skip-permissions`.
+
 [Unreleased]: https://github.com/didvc/ai-bwrap

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The same file can append to `EXTRA_BINDS` (read-write), `EXTRA_RO_BINDS` (read-o
 
 - The host kernel is shared; a kernel-level exploit could escape the sandbox.
 - Anything explicitly bind-mounted is reachable by the agent — keep the passthrough list minimal.
-- The `claude` agent runs with `--dangerously-skip-permissions` on the rationale that the sandbox *is* the boundary, so in-app prompts are redundant. Override by passing your own flags after `--`.
+- Agents run with their own default permission behaviour; `ai-bwrap` adds no flags of its own. If you consider the sandbox boundary sufficient and want to skip in-app prompts, pass the agent's own flag, e.g. `ai-bwrap claude -- --dangerously-skip-permissions`.
 
 See [SECURITY.md](SECURITY.md) for the vulnerability reporting process.
 

--- a/ai-bwrap
+++ b/ai-bwrap
@@ -53,9 +53,7 @@ agent_claude() {
         --bind-try    "$HOME/.bun"         "$HOME/.bun"
         --ro-bind-try "$HOME/.local"       "$HOME/.local"
     )
-    # The sandbox itself is the safety boundary, so in-app permission prompts
-    # are redundant here. Override by passing your own flags after `--`.
-    EXEC_CMD=("$(require_cmd claude)" --dangerously-skip-permissions)
+    EXEC_CMD=("$(require_cmd claude)")
 }
 
 # opencode — the opencode AI coding agent.


### PR DESCRIPTION
  ## What & why

  The `claude` agent no longer launches Claude Code with
  `--dangerously-skip-permissions`. It starts in Claude Code's own default
  permission mode, and `ai-bwrap` now passes no flags of its own to any agent.

  The original rationale was that the bwrap sandbox *is* the safety boundary, so
  in-app prompts were redundant. Claude Code's auto mode changes that calculus —
  it already makes sensible in-session decisions, so blanket permission-skipping
  gives up useful signal without buying much back.

  The old behaviour is one flag away, since anything after `--` goes straight to
  the agent:

      ai-bwrap claude -- --dangerously-skip-permissions

  ## Checklist

  - [x] `shellcheck ai-bwrap` is clean
  - [x] `--help` text and README updated together (if the CLI surface changed)
  - [x] Verified with `--dry-run` (paste relevant output below if helpful)

  `shellcheck ai-bwrap scripts/screenshots.sh` passes. The CLI surface itself is
  unchanged — the flag was never listed in `usage()` — so `--help` and both
  README screenshots stay accurate; the README's *security note* is updated to
  describe the new default and the opt-in above.

  `ai-bwrap claude --dry-run` now ends with a bare `claude`, no appended flags
  (paths abbreviated):

      ... --ro-bind-try $HOME/.local $HOME/.local -- $HOME/.local/bin/claude

  ## Notes

  - Behaviour change for existing users on upgrade, so it's recorded under
    `[Unreleased] / Changed` in `CHANGELOG.md`.
  - Only the `claude` agent was ever given a flag by the wrapper; `opencode`,
    `grok`, and `bash` are untouched.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
